### PR TITLE
Handle empty response when retrieving measures

### DIFF
--- a/src/main/java/org/sonar/report/pdf/builder/MeasuresBuilder.java
+++ b/src/main/java/org/sonar/report/pdf/builder/MeasuresBuilder.java
@@ -135,7 +135,11 @@ public class MeasuresBuilder {
     query.setDepth(0);
     query.setIncludeTrends(true);
     Resource resource = sonar.find(query);
-    this.addAllMeasuresFromDocument(measures, resource);
+    if (resource != null) {
+      this.addAllMeasuresFromDocument(measures, resource);
+    } else {
+      LOG.warn("Empty response when looking for measures: " + measuresAsString.toString());
+    }
   }
 
   private void addAllMeasuresFromDocument(final Measures measures, final Resource resource) {

--- a/src/main/java/org/sonar/report/pdf/builder/MeasuresBuilder.java
+++ b/src/main/java/org/sonar/report/pdf/builder/MeasuresBuilder.java
@@ -138,7 +138,7 @@ public class MeasuresBuilder {
     if (resource != null) {
       this.addAllMeasuresFromDocument(measures, resource);
     } else {
-      LOG.warn("Empty response when looking for measures: " + measuresAsString.toString());
+      LOG.debug("Empty response when looking for measures: " + measuresAsString.toString());
     }
   }
 


### PR DESCRIPTION
Fixes a null exception when sonar.find doesn't return anything.