### PR TITLE
Fix passing credentials when uploading PDF to the server

### DIFF
--- a/src/main/java/org/sonar/report/pdf/batch/PDFPostJob.java
+++ b/src/main/java/org/sonar/report/pdf/batch/PDFPostJob.java
@@ -83,7 +83,7 @@ public class PDFPostJob implements PostJob, CheckProject {
 
     File pdf = new File(path);
     if (pdf.exists()) {
-      FileUploader.upload(pdf, sonarHostUrl + "/pdf_report/store");
+      FileUploader.upload(pdf, sonarHostUrl + "/pdf_report/store", username, password);
     } else {
       LOG.error("PDF file not found in local filesystem. Report could not be sent to server.");
     }

--- a/src/main/java/org/sonar/report/pdf/util/FileUploader.java
+++ b/src/main/java/org/sonar/report/pdf/util/FileUploader.java
@@ -22,8 +22,11 @@ package org.sonar.report.pdf.util;
 
 import java.io.File;
 
+import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.multipart.FilePart;
 import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
@@ -36,7 +39,7 @@ public class FileUploader {
 
   private static final Logger LOG = LoggerFactory.getLogger(PDFPostJob.class);
 
-  public static void upload(final File file, final String url) {
+  public static void upload(final File file, final String url, String username, String password) {
     PostMethod filePost = new PostMethod(url);
 
     try {
@@ -47,6 +50,11 @@ public class FileUploader {
       filePost.setRequestEntity(new MultipartRequestEntity(parts, filePost.getParams()));
 
       HttpClient client = new HttpClient();
+      if (username != null && !username.isEmpty() && password != null && !password.isEmpty()) {
+        client.getParams().setAuthenticationPreemptive(true);
+        Credentials credentials = new UsernamePasswordCredentials(username, password);
+        client.getState().setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT), credentials);
+      }
       client.getHttpConnectionManager().getParams().setConnectionTimeout(10000);
       int status = client.executeMethod(filePost);
       if (status == HttpStatus.SC_OK) {


### PR DESCRIPTION
Without this fix, uploading PDF to Sonar server that requires authentication does not work, because the server redirects to login page when upload request is issued.